### PR TITLE
remove jaeger UDP service ports

### DIFF
--- a/helm-charts/scv2-all-in-one/Chart.yaml
+++ b/helm-charts/scv2-all-in-one/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
 - email: hello@seldon
   name: Seldon Tech Team
 type: application
-version: 0.2
+version: 0.2.1
 # The version of Seldon Core V2 being installed
 appVersion: 2.3.0
 dependencies:

--- a/helm-charts/scv2-all-in-one/charts/jaeger-all-in-one/templates/service.yaml
+++ b/helm-charts/scv2-all-in-one/charts/jaeger-all-in-one/templates/service.yaml
@@ -13,18 +13,18 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: 6831
-      targetPort: udp-com-thr
-      protocol: UDP
-      name: udp-com-thr
-    - port: 6832
-      targetPort: udp-bin-thr
-      protocol: UDP
-      name: udp-bin-thr
-    - port: 5775
-      targetPort: udp-bin-thr-o
-      protocol: UDP
-      name: udp-bin-thr-o
+#    - port: 6831
+#      targetPort: udp-com-thr
+#      protocol: UDP
+#      name: udp-com-thr
+#    - port: 6832
+#      targetPort: udp-bin-thr
+#      protocol: UDP
+#      name: udp-bin-thr
+#    - port: 5775
+#      targetPort: udp-bin-thr-o
+#      protocol: UDP
+#      name: udp-bin-thr-o
     - port: 5778
       targetPort: http-configs
       protocol: TCP

--- a/helm-charts/scv2-all-in-one/charts/jaeger-all-in-one/templates/service.yaml
+++ b/helm-charts/scv2-all-in-one/charts/jaeger-all-in-one/templates/service.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+# UDP points commented out as mixed protocols not allowed for loadbalancers in <1.24 k8s
+# At some point can extend chart with two services?
 #    - port: 6831
 #      targetPort: udp-com-thr
 #      protocol: UDP

--- a/helm-charts/scv2-all-in-one/charts/jaeger-all-in-one/templates/service.yaml
+++ b/helm-charts/scv2-all-in-one/charts/jaeger-all-in-one/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-# UDP points commented out as mixed protocols not allowed for loadbalancers in <1.24 k8s
+# UDP pors commented out as mixed protocols not allowed for loadbalancers in <1.24 k8s
 # At some point can extend chart with two services?
 #    - port: 6831
 #      targetPort: udp-com-thr


### PR DESCRIPTION
Need to remove UDP ports so loadbalancer on older k8s  <1.24 can be created as mixed port protocols not allowed:
otherwise you get the error

Error: UPGRADE FAILED: failed to create resource: Service "scv2-all-in-one-jaeger-all-in-one" is invalid: spec.ports: Invalid value: []core.ServicePort{core.ServicePort{Name:"udp-com-thr", Protocol:"UDP", AppProtocol:(*string)(nil), Port:6831, TargetPort:intstr.IntOrString{Type:1, IntVal:0, StrVal:"udp-com-thr"}, NodePort:0}, core.ServicePort{Name:"udp-bin-thr", Protocol:"UDP", AppProtocol:(*string)(nil), Port:6832, TargetPort:intstr.IntOrString{Type:1, IntVal:0, StrVal:"udp-bin-thr"}, NodePort:0}, core.ServicePort{Name:"udp-bin-thr-o", Protocol:"UDP", AppProtocol:(*string)(nil), Port:5775, TargetPort:intstr.IntOrString{Type:1, IntVal:0, StrVal:"udp-bin-thr-o"}, NodePort:0}, core.ServicePort{Name:"http-configs", Protocol:"TCP", AppProtocol:(*string)(nil), Port:5778, TargetPort:intstr.IntOrString{Type:1, IntVal:0, StrVal:"http-configs"}, NodePort:0}, core.ServicePort{Name:"http-ui", Protocol:"TCP", AppProtocol:(*string)(nil), Port:16686, TargetPort:intstr.IntOrString{Type:1, IntVal:0, StrVal:"http-ui"}, NodePort:0}, core.ServicePort{Name:"grpc-proto", Protocol:"TCP", AppProtocol:(*string)(nil), Port:14250, TargetPort:intstr.IntOrString{Type:1, IntVal:0, StrVal:"grpc-proto"}, NodePort:0}, core.ServicePort{Name:"http-bin-thr", Protocol:"TCP", AppProtocol:(*string)(nil), Port:14268, TargetPort:intstr.IntOrString{Type:1, IntVal:0, StrVal:"http-bin-thr"}, NodePort:0}, core.ServicePort{Name:"http-admin", Protocol:"TCP", AppProtocol:(*string)(nil), Port:14269, TargetPort:intstr.IntOrString{Type:1, IntVal:0, StrVal:"http-admin"}, NodePort:0}}: may not contain more than 1 protocol when type is 'LoadBalancer

