### PR TITLE
Make rclone config_secrets configurable in values.yaml

### DIFF
--- a/helm-charts/seldon-core-v2-setup/templates/agent.yaml
+++ b/helm-charts/seldon-core-v2-setup/templates/agent.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   agent.yaml: |-
     rclone:
-      config_secrets: ["seldon-rclone-gs-public"]
+      config_secrets: {{ .Values.rclone.configSecrets }}

--- a/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/helm-charts/seldon-core-v2-setup/values.yaml
@@ -268,3 +268,6 @@ serverConfig:
 # the names of ports handling gRPC/HTTP2 traffic.
 # For Istio, use 'grpc-' or 'http2-', noting the trailing '-'.
 serviceGRPCPrefix: ""
+
+rclone:
+  configSecrets: '["seldon-rclone-gs-public"]'


### PR DESCRIPTION
The docs detail adding rclone secrets which can be used to connect to different storage providers (https://deploy.seldon.io/en/v2.0/contents/operations/storage-initializers/index.html?highlight=storage%20initializers). However, this is currently hard-coded in the helm chart with `config_secrets: ["seldon-rclone-gs-public"]` so it is only possible to edit using `kubectl`. This means GitOps users (e.g. ArgoCD) don't have an easy way to set up alternative secrets.

This change moves the default `config_secrets` to values.yaml so it can be edited easily.

As per https://seldonio.atlassian.net/servicedesk/customer/portal/1/CSM-606.