### PR TITLE
fix: Separate limits and requests in resource requirements and make them configurable in Core 2

### DIFF
--- a/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -871,11 +871,12 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            memory: '{{ .Values.controller.resources.memory }}'
           requests:
-            cpu: '{{ .Values.controller.resources.cpu }}'
-            memory: '{{ .Values.controller.resources.memory }}'
+            cpu: '{{ .Values.controller.resources.requests.cpu }}'
+            memory: '{{ .Values.controller.resources.requests.memory }}'
+          limits:
+            cpu: '{{ .Values.controller.resources.limits.cpu }}'
+            memory: '{{ .Values.controller.resources.limits.memory }}'
         securityContext:
           allowPrivilegeEscalation: false
 {{- with .Values.imagePullSecrets }}
@@ -973,11 +974,12 @@ spec:
         - containerPort: 9008
           name: dataflow
         resources:
-          limits:
-            memory: '{{ .Values.scheduler.resources.memory }}'
           requests:
-            cpu: '{{ .Values.scheduler.resources.cpu }}'
-            memory: '{{ .Values.scheduler.resources.memory }}'
+            cpu: '{{ .Values.scheduler.resources.requests.cpu }}'
+            memory: '{{ .Values.scheduler.resources.requests.memory }}'
+          limits:
+            cpu: '{{ .Values.scheduler.resources.limits.cpu }}'
+            memory: '{{ .Values.scheduler.resources.limits.memory }}'
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -1008,7 +1010,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: '{{ .Values.scheduler.resources.storage }}'
+            storage: '{{ .Values.scheduler.resources.requests.storage }}'
   - name: seldon-pipelinegateway
     podSpec:
       containers:
@@ -1119,11 +1121,12 @@ spec:
           name: metrics
           protocol: TCP
         resources:
-          limits:
-            memory: '{{ .Values.pipelinegateway.resources.memory }}'
           requests:
-            cpu: '{{ .Values.pipelinegateway.resources.cpu }}'
-            memory: '{{ .Values.pipelinegateway.resources.memory }}'
+            cpu: '{{ .Values.pipelinegateway.resources.requests.cpu }}'
+            memory: '{{ .Values.pipelinegateway.resources.liimts.memory }}'
+          limits:
+            cpu: '{{ .Values.pipelinegateway.resources.requests.cpu }}'
+            memory: '{{ .Values.pipelinegateway.resources.liimts.memory }}'
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -1237,11 +1240,12 @@ spec:
         imagePullPolicy: '{{ .Values.modelgateway.image.pullPolicy }}'
         name: modelgateway
         resources:
-          limits:
-            memory: '{{ .Values.modelgateway.resources.memory }}'
           requests:
-            cpu: '{{ .Values.modelgateway.resources.cpu }}'
-            memory: '{{ .Values.modelgateway.resources.memory }}'
+            cpu: '{{ .Values.modelgateway.resources.requests.cpu }}'
+            memory: '{{ .Values.modelgateway.resources.requests.memory }}'
+          limits:
+            cpu: '{{ .Values.modelgateway.resources.limits.cpu }}'
+            memory: '{{ .Values.modelgateway.resources.limits.memory }}'
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -1305,11 +1309,12 @@ spec:
         imagePullPolicy: '{{ .Values.hodometer.image.pullPolicy }}'
         name: hodometer
         resources:
-          limits:
-            memory: '{{ .Values.hodometer.resources.memory }}'
           requests:
-            cpu: '{{ .Values.hodometer.resources.cpu }}'
-            memory: '{{ .Values.hodometer.resources.memory }}'
+            cpu: '{{ .Values.hodometer.resources.requests.cpu }}'
+            memory: '{{ .Values.hodometer.resources.requests.memory }}'
+          limits:
+            cpu: '{{ .Values.hodometer.resources.limits.cpu }}'
+            memory: '{{ .Values.hodometer.resources.limits.memory }}'
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}
@@ -1361,11 +1366,12 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
         resources:
-          limits:
-            memory: '{{ .Values.envoy.resources.memory }}'
           requests:
-            cpu: '{{ .Values.envoy.resources.cpu }}'
-            memory: '{{ .Values.envoy.resources.memory }}'
+            cpu: '{{ .Values.envoy.resources.requests.cpu }}'
+            memory: '{{ .Values.envoy.resources.requests.memory }}'
+          limits:
+            cpu: '{{ .Values.envoy.resources.limits.cpu }}'
+            memory: '{{ .Values.envoy.resources.limits.memory }}'
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}
@@ -1441,11 +1447,12 @@ spec:
         imagePullPolicy: '{{ .Values.dataflow.image.pullPolicy }}'
         name: dataflow-engine
         resources:
-          limits:
-            memory: '{{ .Values.dataflow.resources.memory }}'
           requests:
-            cpu: '{{ .Values.dataflow.resources.cpu }}'
-            memory: '{{ .Values.dataflow.resources.memory }}'
+            cpu: '{{ .Values.dataflow.resources.requests.cpu }}'
+            memory: '{{ .Values.dataflow.resources.requests.memory }}'
+          limits:
+            cpu: '{{ .Values.dataflow.resources.limits.memory }}'
+            memory: '{{ .Values.dataflow.resources.limits.memory }}'
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}
@@ -1512,11 +1519,12 @@ spec:
           port: 5572
         timeoutSeconds: 1
       resources:
-        limits:
-          memory: '{{ .Values.serverConfig.rclone.resources.memory }}'
         requests:
-          cpu: '{{ .Values.serverConfig.rclone.resources.cpu }}'
-          memory: '{{ .Values.serverConfig.rclone.resources.memory }}'
+          cpu: '{{ .Values.serverConfig.rclone.resources.requests.cpu }}'
+          memory: '{{ .Values.serverConfig.rclone.resources.requests.memory }}'
+        limits:
+          cpu: '{{ .Values.serverConfig.rclone.resources.limits.cpu }}'
+          memory: '{{ .Values.serverConfig.rclone.resources.limits.memory }}'
       volumeMounts:
       - mountPath: /mnt/agent
         name: mlserver-models
@@ -1628,11 +1636,12 @@ spec:
         name: metrics
         protocol: TCP
       resources:
-        limits:
-          memory: '{{ .Values.serverConfig.agent.resources.memory }}'
         requests:
-          cpu: '{{ .Values.serverConfig.agent.resources.cpu }}'
-          memory: '{{ .Values.serverConfig.agent.resources.memory }}'
+          cpu: '{{ .Values.serverConfig.agent.resources.requests.cpu }}'
+          memory: '{{ .Values.serverConfig.agent.resources.requests.memory }}'
+        limits:
+          cpu: '{{ .Values.serverConfig.agent.resources.limits.cpu }}'
+          memory: '{{ .Values.serverConfig.agent.resources.limits.memory }}'
       volumeMounts:
       - mountPath: /mnt/agent
         name: mlserver-models
@@ -1682,11 +1691,12 @@ spec:
         initialDelaySeconds: 5
         periodSeconds: 5
       resources:
-        limits:
-          memory: '{{ .Values.serverConfig.mlserver.resources.memory }}'
         requests:
-          cpu: '{{ .Values.serverConfig.mlserver.resources.cpu }}'
-          memory: '{{ .Values.serverConfig.mlserver.resources.memory }}'
+          cpu: '{{ .Values.serverConfig.mlserver.resources.requests.cpu }}'
+          memory: '{{ .Values.serverConfig.mlserver.resources.requests.memory }}'
+        limits:
+          cpu: '{{ .Values.serverConfig.mlserver.resources.limits.cpu }}'
+          memory: '{{ .Values.serverConfig.mlserver.resources.limits.memory }}'
       startupProbe:
         failureThreshold: 10
         httpGet:
@@ -1760,11 +1770,12 @@ spec:
           port: 5572
         timeoutSeconds: 1
       resources:
-        limits:
-          memory: '{{ .Values.serverConfig.rclone.resources.memory }}'
         requests:
-          cpu: '{{ .Values.serverConfig.rclone.resources.cpu }}'
-          memory: '{{ .Values.serverConfig.rclone.resources.memory }}'
+          cpu: '{{ .Values.serverConfig.rclone.resources.requests.cpu }}'
+          memory: '{{ .Values.serverConfig.rclone.resources.requests.memory }}'
+        limits:
+          cpu: '{{ .Values.serverConfig.rclone.resources.limits.cpu }}'
+          memory: '{{ .Values.serverConfig.rclone.resources.limits.memory }}'
       volumeMounts:
       - mountPath: /mnt/agent
         name: triton-models
@@ -1868,11 +1879,12 @@ spec:
         name: metrics
         protocol: TCP
       resources:
-        limits:
-          memory: '{{ .Values.serverConfig.agent.resources.memory }}'
         requests:
-          cpu: '{{ .Values.serverConfig.agent.resources.cpu }}'
-          memory: '{{ .Values.serverConfig.agent.resources.memory }}'
+          cpu: '{{ .Values.serverConfig.agent.resources.requests.cpu }}'
+          memory: '{{ .Values.serverConfig.agent.resources.requests.memory }}'
+        limits:
+          cpu: '{{ .Values.serverConfig.agent.resources.limits.cpu }}'
+          memory: '{{ .Values.serverConfig.agent.resources.limits.memory }}'
       volumeMounts:
       - mountPath: /mnt/agent
         name: triton-models
@@ -1925,11 +1937,12 @@ spec:
         initialDelaySeconds: 5
         periodSeconds: 5
       resources:
-        limits:
-          memory: '{{ .Values.serverConfig.triton.resources.memory }}'
         requests:
-          cpu: '{{ .Values.serverConfig.triton.resources.cpu }}'
-          memory: '{{ .Values.serverConfig.triton.resources.memory }}'
+          cpu: '{{ .Values.serverConfig.triton.resources.requests.cpu }}'
+          memory: '{{ .Values.serverConfig.triton.resources.requests.memory }}'
+        limits:
+          cpu: '{{ .Values.serverConfig.triton.resources.limits.cpu }}'
+          memory: '{{ .Values.serverConfig.triton.resources.limits.memory }}'
       startupProbe:
         failureThreshold: 10
         httpGet:

--- a/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1123,10 +1123,10 @@ spec:
         resources:
           requests:
             cpu: '{{ .Values.pipelinegateway.resources.requests.cpu }}'
-            memory: '{{ .Values.pipelinegateway.resources.liimts.memory }}'
+            memory: '{{ .Values.pipelinegateway.resources.limits.memory }}'
           limits:
             cpu: '{{ .Values.pipelinegateway.resources.requests.cpu }}'
-            memory: '{{ .Values.pipelinegateway.resources.liimts.memory }}'
+            memory: '{{ .Values.pipelinegateway.resources.limits.memory }}'
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -1451,7 +1451,7 @@ spec:
             cpu: '{{ .Values.dataflow.resources.requests.cpu }}'
             memory: '{{ .Values.dataflow.resources.requests.memory }}'
           limits:
-            cpu: '{{ .Values.dataflow.resources.limits.memory }}'
+            cpu: '{{ .Values.dataflow.resources.limits.cpu }}'
             memory: '{{ .Values.dataflow.resources.limits.memory }}'
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/helm-charts/seldon-core-v2-setup/values.yaml
@@ -88,8 +88,12 @@ hodometer:
   metricsLevel: feature
   extraPublishUrls: ""
   resources:
-    cpu: 1m
-    memory: 32Mi
+    requests:
+      cpu: 1m
+      memory: 32Mi
+    limits:
+      cpu:
+      memory: 32Mi
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -123,8 +127,12 @@ modelgateway:
     tag: 2.7.0
   workers: 8
   resources:
-    cpu: 100m
-    memory: 1G
+    requests:
+      cpu: 100m
+      memory: 1G
+    limits:
+      cpu:
+      memory: 1G
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -138,8 +146,12 @@ pipelinegateway:
     repository: seldonio/seldon-pipelinegateway
     tag: 2.7.0
   resources:
-    cpu: 100m
-    memory: 1G
+    requests:
+      cpu: 100m
+      memory: 1G
+    limits:
+      cpu:
+      memory: 1G
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -154,8 +166,12 @@ dataflow:
     tag: 2.7.0
   cores: 4
   resources:
-    cpu: 100m
-    memory: 1G
+    requests:
+      cpu: 100m
+      memory: 1G
+    limits:
+      cpu:
+      memory: 1G
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -170,8 +186,12 @@ controller:
     repository: seldonio/seldonv2-controller
     tag: 2.7.0
   resources:
-    cpu: 10m
-    memory: 64Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu:
+      memory: 64Mi
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -185,8 +205,12 @@ envoy:
     repository: seldonio/seldon-envoy
     tag: 2.7.0
   resources:
-    cpu: 100m
-    memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu:
+      memory: 128Mi
   service:
     type: LoadBalancer
   securityContext:
@@ -202,9 +226,13 @@ scheduler:
     repository: seldonio/seldon-scheduler
     tag: 2.7.0
   resources:
-    cpu: 100m
-    memory: 1Gi
-    storage: 1Gi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+      storage: 1Gi
+    limits:
+      cpu:
+      memory: 128Mi
   service:
     type: LoadBalancer
   securityContext:
@@ -229,8 +257,12 @@ serverConfig:
       repository: seldonio/seldon-rclone
       tag: 2.7.0
     resources:
-      cpu: 50m
-      memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu:
+        memory: 128Mi
 
   agent:
     image:
@@ -243,8 +275,12 @@ serverConfig:
     modelInferenceLagThreshold: "30"
     modelInactiveSecondsThreshold: "600"
     resources:
-      cpu: 200m
-      memory: 1Gi
+      requests:
+        cpu: 200m
+        memory: 1Gi
+      limits:
+        cpu:
+        memory: 1Gi
 
   mlserver:
     image:
@@ -255,8 +291,12 @@ serverConfig:
     serverCapabilities: "mlserver,alibi-detect,alibi-explain,huggingface,lightgbm,mlflow,python,sklearn,spark-mlib,xgboost"
     modelVolumeStorage: 1Gi
     resources:
-      cpu: 100m
-      memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
+      limits:
+        cpu:
+        memory: 1Gi
 
   triton:
     image:
@@ -267,8 +307,12 @@ serverConfig:
     serverCapabilities: "triton,dali,fil,onnx,openvino,python,pytorch,tensorflow,tensorrt"
     modelVolumeStorage: 1Gi
     resources:
-      cpu: 100m
-      memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
+      limits:
+        cpu:
+        memory: 1Gi
 
 services:
 # For use with service meshes like Istio, which require specific prefixes for


### PR DESCRIPTION
Previously limits for resources were not set in Helm templates, this PR allows resource requirement configurable from Helm values